### PR TITLE
Añadir capacidad para devolver un objeto basado en resultados

### DIFF
--- a/SweetAlert.js
+++ b/SweetAlert.js
@@ -12,17 +12,29 @@ export const ngSweetAlert = angular.module('wisboo.ngSweetAlert2', [])
 	.service('sweetAlert', ['$timeout', 'icons', '$q', function ($timeout, icons, $q) {
 		//public methods
 		let customSwal;
+		
+		const generateResultObject = (result) => ({
+			...result,
+			isCancelled: result.dismiss === 'cancel',
+			isBackdropped: result.dismiss === 'backdrop',
+			isClosed: result.dismiss === 'close'
+		});
+
 		this.setGlobals = (customParams) => {
       customSwal = Swal.mixin(customParams);
-    };
+		};
 
-		this.adv = (object) => {
+		this.adv = ({ returnResultObject = false, ...object }) => {
 			return $q(function (resolve, reject) {
 				customSwal.fire(object).then(function (result) {
-					if (result.value || !result.dismiss) {
-						resolve(true, result.value);
+					if (returnResultObject) {
+						resolve(generateResultObject(result));
 					} else {
-						resolve(false);
+						if (result.value || !result.dismiss) {
+							resolve(true, result.value);
+						} else {
+							resolve(false);
+						}
 					}
 				});
 			});

--- a/dist/ngsweetalert.js
+++ b/dist/ngsweetalert.js
@@ -4,8 +4,13 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
+var _objectWithoutProperties = _interopDefault(require('@babel/runtime/helpers/objectWithoutProperties'));
+var _defineProperty = _interopDefault(require('@babel/runtime/helpers/defineProperty'));
 var Swal = _interopDefault(require('sweetalert2/dist/sweetalert2.js'));
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 var ngSweetAlert = angular.module('wisboo.ngSweetAlert2', []).constant('icons', {
   success: 'https://2.cdn.wisboo.com/images/sa_done.svg',
   warning: 'https://2.cdn.wisboo.com/images/sa_alert.svg',
@@ -18,17 +23,33 @@ var ngSweetAlert = angular.module('wisboo.ngSweetAlert2', []).constant('icons', 
   //public methods
   var customSwal;
 
+  var generateResultObject = function generateResultObject(result) {
+    return _objectSpread(_objectSpread({}, result), {}, {
+      isCancelled: result.dismiss === 'cancel',
+      isBackdropped: result.dismiss === 'backdrop',
+      isClosed: result.dismiss === 'close'
+    });
+  };
+
   this.setGlobals = function (customParams) {
     customSwal = Swal.mixin(customParams);
   };
 
-  this.adv = function (object) {
+  this.adv = function (_ref) {
+    var _ref$returnResultObje = _ref.returnResultObject,
+        returnResultObject = _ref$returnResultObje === void 0 ? false : _ref$returnResultObje,
+        object = _objectWithoutProperties(_ref, ["returnResultObject"]);
+
     return $q(function (resolve, reject) {
       customSwal.fire(object).then(function (result) {
-        if (result.value || !result.dismiss) {
-          resolve(true, result.value);
+        if (returnResultObject) {
+          resolve(generateResultObject(result));
         } else {
-          resolve(false);
+          if (result.value || !result.dismiss) {
+            resolve(true, result.value);
+          } else {
+            resolve(false);
+          }
         }
       });
     });


### PR DESCRIPTION
Permite consultar mas facilmente en el front en forma de API los resultados del sweet alert